### PR TITLE
feat: Stress Testing

### DIFF
--- a/lua/competitest/init.lua
+++ b/lua/competitest/init.lua
@@ -76,6 +76,7 @@ local default_config = {
 		python = { exec = "python", args = { "$(FNAME)" } },
 		java = { exec = "java", args = { "$(FNOEXT)" } },
 	},
+
 	multiple_testing = -1, -- how many testcases to run at the same time. Set it to 0 to run all them together, -1 to use the number of available cpu cores, or any positive number to run how many testcases you want
 	maximum_time = 5000, -- maximum time (in milliseconds) given to a process. If it's excedeed process will be killed
 	output_compare_method = "squish", -- "exact", "squish" or custom function returning true if comparison is valid
@@ -87,6 +88,8 @@ local default_config = {
 	testcases_use_single_file = false,
 	testcases_single_file_format = "$(FNOEXT).testcases",
 	testcases_directory = ".", -- where testcases are located, relatively to current file's path
+
+	output_to_file = true,
 
 	companion_port = 27121, -- competitive companion port
 	receive_print_message = true,


### PR DESCRIPTION
- Saving output to file will enable us to compare test.out and test.ans with custom code. E.x: floating compare, ignore extra spaces, see https://github.com/Aeren1564/Tools for example
- Generated big test can be opened without lag (1e7 chars). https://judge.yosupo.jp/ is a good example with their randomly generated tests: https://github.com/yosupo06/library-checker-problems
- Why don't we straight up using `g++ sol.cpp < 1.in > 1.out 2> 1.err` 🤔 