### PR TITLE
fix error cause by getting no. of cpu cores with cpu_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ require('competitest').setup {
 - `run_command`: configure the command used to run your solutions for every different language, see [here](#customize-compile-and-run-commands)
 
 - `multiple_testing`: how many testcases to run at the same time
-	- set it to `-1` if you want to run as many testcases as the number of available CPU cores at the same time
+	- set it to `-1` to make the most of the amount of available parallelism. Often the number of testcases run at the same time coincides with the number of CPUs
 	- set it to `0` if you want to run all the testcases together
 	- set it to any positive integer to run that number of testcases contemporarily
 - `maximum_time`: maximum time, in milliseconds, given to processes. If it's exceeded process will be killed

--- a/lua/competitest/init.lua
+++ b/lua/competitest/init.lua
@@ -117,7 +117,7 @@ local default_config = {
 		python = { exec = "python", args = { "$(FNAME)" } },
 		java = { exec = "java", args = { "$(FNOEXT)" } },
 	},
-	multiple_testing = -1, -- how many testcases to run at the same time. Set it to 0 to run all them together, -1 to use the number of available cpu cores, or any positive number to run how many testcases you want
+	multiple_testing = -1, -- how many testcases to run at the same time. Set it to 0 to run all them together, -1 to use amount of available parallelism, or any positive number to run how many testcases you want
 	maximum_time = 5000, -- maximum time (in milliseconds) given to a process. If it's excedeed process will be killed
 	output_compare_method = "squish", -- "exact", "squish" or custom function returning true if comparison is valid
 

--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -94,7 +94,7 @@ function TCRunner:run_testcases(tctbl, compile)
 	local tc_size = #self.tcdata -- how many testcases
 	local mut = self.config.multiple_testing -- multiple testing, how many testcases to run at the same time
 	if mut == -1 then -- -1 -> use the number of available cpu cores
-		mut = #luv.cpu_info()
+		mut = luv.available_parallelism()
 	elseif mut == 0 then -- 0 -> run all testcases together
 		mut = tc_size
 	end

--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -93,8 +93,13 @@ function TCRunner:run_testcases(tctbl, compile)
 
 	local tc_size = #self.tcdata -- how many testcases
 	local mut = self.config.multiple_testing -- multiple testing, how many testcases to run at the same time
-	if mut == -1 then -- -1 -> use the number of available cpu cores
-		mut = luv.available_parallelism()
+	if mut == -1 then -- -1 -> make the most of the amount of available parallelism
+		if luv.available_parallelism then
+			mut = luv.available_parallelism()
+		else -- vim.loop.available_parallelism() isn't available in Neovim < 0.7.2
+			local cpu_info = luv.cpu_info()
+			mut = cpu_info and #cpu_info or 1
+		end
 	elseif mut == 0 then -- 0 -> run all testcases together
 		mut = tc_size
 	end


### PR DESCRIPTION
This fix an error cause by #[luv.cpu_info()](https://github.com/luvit/luv/blob/master/docs.md#uvcpu_info) when it return `fail`, using [luv.avaliable_parallelism()](https://github.com/luvit/luv/blob/master/docs.md#uvavailable_parallelism) instead can resolve this problem as it always return an **non-zero integer**, and using uv.avaliable_parallelism seems to be a more suitable solution, as it can **return an estimate of the default amount of parallelism a program should use**.