### PR TITLE
autocommands for writing and closing editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ When launching the following commands make sure the focused buffer is the one co
 Launch `:CompetiTestAdd` to add a new testcase.\
 Launch `:CompetiTestEdit` to edit an existing testcase. If you want to specify testcase number directly in the command line you can use `:CompetiTestEdit x`, where `x` is a number representing the testcase you want to edit.
 
-To jump between input and output windows press either `<C-h>`, `<C-l>`, or `<C-i>`. To save and close testcase editor press `<C-s>`.
+To jump between input and output windows press either `<C-h>`, `<C-l>`, or `<C-i>`. To save and close testcase editor press `<C-s>` or `:wq`.
 
 Of course these keybindings can be customized: see `editor_ui` ➤ `normal_mode_mappings` and `editor_ui` ➤ `insert_mode_mappings` in [configuration](#configuration)
 
@@ -111,7 +111,7 @@ One of the following arguments is needed:
 **NOTE:** this command only converts already existing testcases files without changing CompetiTest configuration. To choose the storage method to use you have to [configure](#configuration) `testcases_use_single_file` option, that is false by default. Anyway storage method can be automatically detected when option `testcases_auto_detect_storage` is true.
 
 ### Run testcases
-Launch `:CompetiTestRun`. CompetiTest's interface will appear and you'll be able to view details about a testcase by moving the cursor over its entry. You can close the UI by pressing `q` or `Q`.\
+Launch `:CompetiTestRun`. CompetiTest's interface will appear and you'll be able to view details about a testcase by moving the cursor over its entry. You can close the UI by pressing `q`, `Q` or `:q`.\
 If you're using a compiled language and you don't want to recompile your program launch `:CompetiTestRunNC`, where "NC" means "No Compile".\
 If you have previously closed the UI and you want to re-open it without re-executing testcases or recompiling launch `:CompetiTestRunNE`, where "NE" means "No Execute".
 

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -105,6 +105,17 @@ function RunnerUI:show_ui()
 			for n, w in pairs(self.windows) do
 				if n ~= "vw" then
 					w:map("n", map, hide_ui, { noremap = true })
+
+					w:on(nui_event.QuitPre, function() -- close windows with ":q"
+						local winid -- window of buffer shown in viewer
+						if self.viewer_visible and n == self.viewer_content then
+							winid = w.winid
+						end
+						self:delete()
+						if winid and api.nvim_win_is_valid(winid) then -- workaround to close last split
+							api.nvim_buf_delete(api.nvim_win_get_buf(winid), { force = true })
+						end
+					end)
 				end
 			end
 		end
@@ -248,10 +259,10 @@ function RunnerUI:delete()
 	if self.ui_visible then
 		self:disable_diff_view() -- disable diff when closing windows to prevent conflicts with other diffviews
 	end
-	for _, w in pairs(self.windows) do
+	for name, w in pairs(self.windows) do
 		if w then -- if a window is uninitialized its value is nil
 			w:unmount()
-			w = nil
+			self.windows[name] = nil
 		end
 	end
 	self.ui_initialized = false

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -220,10 +220,12 @@ end
 ---@param winid integer
 ---@param enable_diff boolean
 local function win_set_diff(winid, enable_diff)
-	api.nvim_win_call(winid, function()
-		api.nvim_command(enable_diff and "diffthis" or "diffoff")
-		vim.wo.foldlevel = 1 -- unfold unchanged text
-	end)
+	if winid and api.nvim_win_is_valid(winid) then
+		api.nvim_win_call(winid, function()
+			api.nvim_command(enable_diff and "diffthis" or "diffoff")
+			vim.wo.foldlevel = 1 -- unfold unchanged text
+		end)
+	end
 end
 
 ---Toggle diffview between standard output and expected output windows

--- a/lua/competitest/widgets.lua
+++ b/lua/competitest/widgets.lua
@@ -98,13 +98,6 @@ function M.editor(bufnr, tcnum, input_content, output_content, callback, restore
 	output_popup_settings.position.col = math.floor(vim_width / 2) + 1
 	editor.output_popup = nui_popup(output_popup_settings)
 
-	-- autocommands for writing testcase with ":w", closing UI with ":q" and doing both with ":wq"
-	local nui_event = require("nui.utils.autocmd").event
-	editor.input_popup:on(nui_event.BufWriteCmd, send_data)
-	editor.output_popup:on(nui_event.BufWriteCmd, send_data)
-	editor.input_popup:on(nui_event.QuitPre, delete_ui)
-	editor.output_popup:on(nui_event.QuitPre, delete_ui)
-
 	-- mount/open the component
 	editor.output_popup:mount()
 	api.nvim_buf_set_name(editor.output_popup.bufnr, "CompetiTestEditOutput")
@@ -154,6 +147,13 @@ function M.editor(bufnr, tcnum, input_content, output_content, callback, restore
 	set_popup_keymaps(editor.input_popup, "i", config.editor_ui.insert_mode_mappings, editor.output_popup.winid)
 	set_popup_keymaps(editor.output_popup, "n", config.editor_ui.normal_mode_mappings, editor.input_popup.winid)
 	set_popup_keymaps(editor.output_popup, "i", config.editor_ui.insert_mode_mappings, editor.input_popup.winid)
+
+	-- autocommands for writing testcase with ":w", closing UI with ":q" and doing both with ":wq"
+	local nui_event = require("nui.utils.autocmd").event
+	editor.input_popup:on(nui_event.BufWriteCmd, send_data)
+	editor.output_popup:on(nui_event.BufWriteCmd, send_data)
+	editor.input_popup:on(nui_event.WinClosed, delete_ui)
+	editor.output_popup:on(nui_event.WinClosed, delete_ui)
 
 	-- set content
 	api.nvim_buf_set_lines(editor.input_popup.bufnr, 0, 1, false, input_content)


### PR DESCRIPTION
This PR is implementation of some features requested in #24 . Specifically it implements the following:
- While closing a single editor window (using :q or other quit commands), this closes the other one too. So, normal quit commands can be used to quit the window
- Now, the buffer supports saving testcases. The implementation doesn't bother if we are using msgpack-single-file feature or not. As, it just calls the callback provided to editor function with appropriate content. Here, if I save input, it saves output automatically and vice-versa.
- And thus :wq and other similar commands work seamlessly.

There is a similar feature that can be developed over similar lines and maybe pushed with same PR, that is to close other competitest runner window, when we close one of them (using :q)

The intent of the PR is to make competitest UI interaction work as close as possible to native vim keybindings, so that adding any testcase and other operations can be made as fast as using native vim keybindings.

We can discuss if these changes are aligned to project goals or not. And if there are any changes necessary for PR, we can do the same.

Thanks,
Rishabh Dwivedi