### PR TITLE
feat: head comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [Delete](#remove-a-testcase) a testcase with `:CompetiTestDelete`
 - [Run](#run-testcases) your program across all the testcases with `:CompetiTestRun`, showing results and execution data in a nice interactive UI
 - [Download](#receive-testcases-problems-and-contests) testcases, problems and contests automatically from competitive programming platforms with `:CompetiTestReceive`
+- [Templates](#templates-for-received-problems-and-contests) for received problems and contests
 - View diff between actual and expected output
 - [Customizable interface](#customize-ui-layout) that resizes automatically when Neovim window is resized
 - Integration with [statusline and winbar](#statusline-and-winbar-integration)
@@ -149,8 +150,7 @@ Thanks to its integration with [competitive-companion](https://github.com/jmerle
 - Download an entire contest with `:CompetiTestReceive contest` (make sure to be on the homepage of the contest, not of a single problem)
 
 After launching one of these commands click on the green plus button in your browser to start downloading.\
-For further customization see receive options in [configuration](#configuration).\
-When downloading a problem or a contest, source code templates can be configured for different file types. See `template_file` option in [configuration](#configuration).
+For further customization see receive options in [configuration](#configuration).
 
 #### Customize folder structure
 By default CompetiTest stores received problems and contests in current working directory. You can change this behavior through the options `received_problems_path`, `received_contests_directory` and `received_contests_problems_path`. See [receive modifiers](#receive-modifiers) for further details.\
@@ -175,6 +175,27 @@ Here are some tips:
 	``` lua
 	received_contests_problems_path = "$(JAVA_TASK_CLASS).$(FEXT)"
 	```
+
+#### Templates for received problems and contests
+When downloading a problem or a contest, source code templates can be configured for different file types. See `template_file` option in [configuration](#configuration).\
+[Receive modifiers](#receive-modifiers) can be used inside template files to insert details about received problems. To enable this feature set `evaluate_template_modifiers` to `true`. Template example for C++:
+``` cpp
+// Problem: $(PROBLEM)
+// Contest: $(CONTEST)
+// Judge: $(JUDGE)
+// URL: $(URL)
+// Memory Limit: $(MEMLIM)
+// Time Limit: $(TIMELIM)
+// Start: $(DATE)
+
+#include <iostream>
+using namespace std;
+int main() {
+	cout << "This is a template file" << endl;
+	cerr << "Problem name is $(PROBLEM)" << endl;
+	return 0;
+}
+```
 
 ## Configuration
 ### Full configuration
@@ -296,6 +317,7 @@ require('competitest').setup {
 	receive_print_message = true,
 	template_file = false,
 	evaluate_template_modifiers = false,
+	date_format = "%c",
 	received_files_extension = "cpp",
 	received_problems_path = "$(CWD)/$(PROBLEM).$(FEXT)",
 	received_problems_prompt_path = true,
@@ -305,7 +327,6 @@ require('competitest').setup {
 	received_contests_prompt_extension = true,
 	open_received_problems = true,
 	open_received_contests = true,
-	date_format = "%c",
 }
 ```
 
@@ -408,7 +429,8 @@ require('competitest').setup {
 			py = "~/path/to/file.py",
 		}
 		```
-- `evaluate_template_modifier`: whether to evaluate the template file for receive modifiers
+- `evaluate_template_modifiers`: whether to evaluate [receive modifiers](#receive-modifiers) inside a template file or not
+- `date_format`: string used to format `$(DATE)` modifier (see [receive modifiers](#receive-modifiers)). The string should follow the formatting rules as per Lua's [`os.date`](https://www.lua.org/pil/22.1.html) function. For example, to get `06-07-2023 15:24:32` set it to `%d-%m-%Y %H:%M:%S`
 - `received_files_extension`: default file extension for received problems
 - `received_problems_path`: path where received problems (not contests) are stored. Can be one of the following:
 	- string with [receive modifiers](#receive-modifiers)
@@ -434,10 +456,6 @@ require('competitest').setup {
 - `received_contests_prompt_extension`: whether to ask user confirmation about what file extension to when receiving a contests or not
 - `open_received_problems`: automatically open source files when receiving a single problem
 - `open_received_contests`: automatically open source files when receiving a contest
-- `date_format`: string which is used to format the time in the `$(DATE)` modifier. The string should follow the formatting rules as per Lua's [`os.date`](https://www.lua.org/pil/22.1.html) function. For example, to get `06-07-2023 15:24:32`: 
-	```lua
-	time_format = "%d-%m-%Y %H:%M:%S"
-	```
 
 ### Local configuration
 You can use a different configuration for every different folder by creating a file called `.competitest.lua` (this name can be changed configuring the option `local_config_file_name`). It will affect every file contained in that folder and in subfolders. A table containing valid options must be returned, see the following example.
@@ -470,24 +488,24 @@ You can use them to [define commands](#customize-compile-and-run-commands) or to
 | `$(TCNUM)`    | testcase number                            |
 
 #### Receive modifiers
-You can use them to customize the options `received_problems_path`, `received_contests_directory` and `received_contests_problems_path`. See also [tips for customizing folder structure for received problems and contests](#customize-folder-structure).
+You can use them to customize the options `received_problems_path`, `received_contests_directory`, `received_contests_problems_path` and to [insert problem details inside template files](#templates-for-received-problems-and-contests). See also [tips for customizing folder structure for received problems and contests](#customize-folder-structure).
 
-| Modifier             | Meaning                                                        |
-| --------             | -------                                                        |
-| `$()`                | insert a dollar                                                |
-| `$(HOME)`            | user home directory                                            |
-| `$(CWD)`             | current working directory                                      |
-| `$(FEXT)`            | preferred file extension                                       |
-| `$(PROBLEM)`         | problem name, `name` field                                     |
-| `$(GROUP)`           | judge and contest name, `group` field                          |
-| `$(JUDGE)`           | judge name (first part of `group`, before hyphen)              |
-| `$(CONTEST)`         | contest name (second part of `group`, after hyphen)            |
-| `$(URL)`             | problem url, `url` field                                       |
-| `$(MEMLIM)`          | available memory, `memoryLimit` field                          |
-| `$(TIMELIM)`         | time limit, `timeLimit` field                                  |
-| `$(JAVA_MAIN_CLASS)` | almost always "Main", `mainClass` field                        |
-| `$(JAVA_TASK_CLASS)` | classname-friendly version of problem name, `taskClass` field  |
-| `$(DATE)`            | current date and time (based on [`date_format`](#explanation)) |
+| Modifier             | Meaning                                                       |
+| --------             | -------                                                       |
+| `$()`                | insert a dollar                                               |
+| `$(HOME)`            | user home directory                                           |
+| `$(CWD)`             | current working directory                                     |
+| `$(FEXT)`            | preferred file extension                                      |
+| `$(PROBLEM)`         | problem name, `name` field                                    |
+| `$(GROUP)`           | judge and contest name, `group` field                         |
+| `$(JUDGE)`           | judge name (first part of `group`, before hyphen)             |
+| `$(CONTEST)`         | contest name (second part of `group`, after hyphen)           |
+| `$(URL)`             | problem url, `url` field                                      |
+| `$(MEMLIM)`          | available memory, `memoryLimit` field                         |
+| `$(TIMELIM)`         | time limit, `timeLimit` field                                 |
+| `$(JAVA_MAIN_CLASS)` | almost always "Main", `mainClass` field                       |
+| `$(JAVA_TASK_CLASS)` | classname-friendly version of problem name, `taskClass` field |
+| `$(DATE)`            | current date and time (based on [`date_format`](#explanation)), it can be used only inside [template files](#templates-for-received-problems-and-contests) |
 
 Fields are referred to [received tasks](https://github.com/jmerle/competitive-companion/#the-format).
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ require('competitest').setup {
 	companion_port = 27121,
 	receive_print_message = true,
 	template_file = false,
+	evaluate_template_modifiers = false,
 	received_files_extension = "cpp",
 	received_problems_path = "$(CWD)/$(PROBLEM).$(FEXT)",
 	received_problems_prompt_path = true,
@@ -304,6 +305,7 @@ require('competitest').setup {
 	received_contests_prompt_extension = true,
 	open_received_problems = true,
 	open_received_contests = true,
+	date_format = "%c",
 }
 ```
 
@@ -406,6 +408,7 @@ require('competitest').setup {
 			py = "~/path/to/file.py",
 		}
 		```
+- `evaluate_template_modifier`: whether to evaluate the template file for receive modifiers
 - `received_files_extension`: default file extension for received problems
 - `received_problems_path`: path where received problems (not contests) are stored. Can be one of the following:
 	- string with [receive modifiers](#receive-modifiers)
@@ -431,6 +434,10 @@ require('competitest').setup {
 - `received_contests_prompt_extension`: whether to ask user confirmation about what file extension to when receiving a contests or not
 - `open_received_problems`: automatically open source files when receiving a single problem
 - `open_received_contests`: automatically open source files when receiving a contest
+- `date_format`: string which is used to format the time in the `$(DATE)` modifier. The string should follow the formatting rules as per Lua's [`os.date`](https://www.lua.org/pil/22.1.html) function. For example, to get `06-07-2023 15:24:32`: 
+	```lua
+	time_format = "%d-%m-%Y %H:%M:%S"
+	```
 
 ### Local configuration
 You can use a different configuration for every different folder by creating a file called `.competitest.lua` (this name can be changed configuring the option `local_config_file_name`). It will affect every file contained in that folder and in subfolders. A table containing valid options must be returned, see the following example.
@@ -465,21 +472,22 @@ You can use them to [define commands](#customize-compile-and-run-commands) or to
 #### Receive modifiers
 You can use them to customize the options `received_problems_path`, `received_contests_directory` and `received_contests_problems_path`. See also [tips for customizing folder structure for received problems and contests](#customize-folder-structure).
 
-| Modifier             | Meaning                                                       |
-| --------             | -------                                                       |
-| `$()`                | insert a dollar                                               |
-| `$(HOME)`            | user home directory                                           |
-| `$(CWD)`             | current working directory                                     |
-| `$(FEXT)`            | preferred file extension                                      |
-| `$(PROBLEM)`         | problem name, `name` field                                    |
-| `$(GROUP)`           | judge and contest name, `group` field                         |
-| `$(JUDGE)`           | judge name (first part of `group`, before hyphen)             |
-| `$(CONTEST)`         | contest name (second part of `group`, after hyphen)           |
-| `$(URL)`             | problem url, `url` field                                      |
-| `$(MEMLIM)`          | available memory, `memoryLimit` field                         |
-| `$(TIMELIM)`         | time limit, `timeLimit` field                                 |
-| `$(JAVA_MAIN_CLASS)` | almost always "Main", `mainClass` field                       |
-| `$(JAVA_TASK_CLASS)` | classname-friendly version of problem name, `taskClass` field |
+| Modifier             | Meaning                                                        |
+| --------             | -------                                                        |
+| `$()`                | insert a dollar                                                |
+| `$(HOME)`            | user home directory                                            |
+| `$(CWD)`             | current working directory                                      |
+| `$(FEXT)`            | preferred file extension                                       |
+| `$(PROBLEM)`         | problem name, `name` field                                     |
+| `$(GROUP)`           | judge and contest name, `group` field                          |
+| `$(JUDGE)`           | judge name (first part of `group`, before hyphen)              |
+| `$(CONTEST)`         | contest name (second part of `group`, after hyphen)            |
+| `$(URL)`             | problem url, `url` field                                       |
+| `$(MEMLIM)`          | available memory, `memoryLimit` field                          |
+| `$(TIMELIM)`         | time limit, `timeLimit` field                                  |
+| `$(JAVA_MAIN_CLASS)` | almost always "Main", `mainClass` field                        |
+| `$(JAVA_TASK_CLASS)` | classname-friendly version of problem name, `taskClass` field  |
+| `$(DATE)`            | current date and time (based on [`date_format`](#explanation)) |
 
 Fields are referred to [received tasks](https://github.com/jmerle/competitive-companion/#the-format).
 

--- a/lua/competitest/commands.lua
+++ b/lua/competitest/commands.lua
@@ -201,11 +201,12 @@ function M.receive(mode)
 	---@param path string | function: see received_problems_path, received_contests_directory and received_contests_problems_path
 	---@param task table: table with received task data
 	---@param file_extension string
+	---@param date_format string: string used to format date
 	---@return string
-	local function eval_path(path, task, file_extension)
+	local function eval_path(path, task, file_extension, date_format)
 		local init_dir
 		if type(path) == "string" then
-			init_dir = receive.eval_receive_modifiers(path, task, file_extension, true)
+			init_dir = receive.eval_receive_modifiers(path, task, file_extension, true, date_format)
 		elseif type(path) == "function" then
 			init_dir = path(task, file_extension)
 		end
@@ -224,7 +225,7 @@ function M.receive(mode)
 		receive.receive(setup.companion_port, true, "problem", function(tasks)
 			widgets.input(
 				"Choose problem path",
-				eval_path(setup.received_problems_path, tasks[1], setup.received_files_extension),
+				eval_path(setup.received_problems_path, tasks[1], setup.received_files_extension, setup.date_format),
 				setup.floating_border,
 				not setup.received_problems_prompt_path,
 				function(filepath)
@@ -240,7 +241,7 @@ function M.receive(mode)
 		receive.receive(setup.companion_port, false, "contest", function(tasks)
 			widgets.input(
 				"Choose contest directory",
-				eval_path(setup.received_contests_directory, tasks[1], setup.received_files_extension),
+				eval_path(setup.received_contests_directory, tasks[1], setup.received_files_extension, setup.date_format),
 				setup.floating_border,
 				not setup.received_contests_prompt_directory,
 				function(directory)
@@ -252,7 +253,7 @@ function M.receive(mode)
 						not cfg.received_contests_prompt_extension,
 						function(file_extension)
 							for _, task in ipairs(tasks) do
-								local filepath = directory .. "/" .. eval_path(cfg.received_contests_problems_path, task, file_extension)
+								local filepath = directory .. "/" .. eval_path(cfg.received_contests_problems_path, task, file_extension, cfg.date_format)
 								receive.store_problem_config(filepath, true, task, cfg)
 								if cfg.open_received_contests then
 									vim.cmd("edit " .. filepath)

--- a/lua/competitest/commands.lua
+++ b/lua/competitest/commands.lua
@@ -228,7 +228,7 @@ function M.receive(mode)
 				setup.floating_border,
 				not setup.received_problems_prompt_path,
 				function(filepath)
-					receive.store_problem_config(filepath, true, tasks[1].tests, setup)
+					receive.store_problem_config(filepath, true, tasks[1], setup)
 					if setup.open_received_problems then
 						vim.cmd("edit " .. filepath)
 					end
@@ -253,7 +253,7 @@ function M.receive(mode)
 						function(file_extension)
 							for _, task in ipairs(tasks) do
 								local filepath = directory .. "/" .. eval_path(cfg.received_contests_problems_path, task, file_extension)
-								receive.store_problem_config(filepath, true, task.tests, cfg)
+								receive.store_problem_config(filepath, true, task, cfg)
 								if cfg.open_received_contests then
 									vim.cmd("edit " .. filepath)
 								end

--- a/lua/competitest/commands.lua
+++ b/lua/competitest/commands.lua
@@ -201,12 +201,11 @@ function M.receive(mode)
 	---@param path string | function: see received_problems_path, received_contests_directory and received_contests_problems_path
 	---@param task table: table with received task data
 	---@param file_extension string
-	---@param date_format string: string used to format date
 	---@return string
-	local function eval_path(path, task, file_extension, date_format)
+	local function eval_path(path, task, file_extension)
 		local init_dir
 		if type(path) == "string" then
-			init_dir = receive.eval_receive_modifiers(path, task, file_extension, true, date_format)
+			init_dir = receive.eval_receive_modifiers(path, task, file_extension, true)
 		elseif type(path) == "function" then
 			init_dir = path(task, file_extension)
 		end
@@ -225,7 +224,7 @@ function M.receive(mode)
 		receive.receive(setup.companion_port, true, "problem", function(tasks)
 			widgets.input(
 				"Choose problem path",
-				eval_path(setup.received_problems_path, tasks[1], setup.received_files_extension, setup.date_format),
+				eval_path(setup.received_problems_path, tasks[1], setup.received_files_extension),
 				setup.floating_border,
 				not setup.received_problems_prompt_path,
 				function(filepath)
@@ -241,7 +240,7 @@ function M.receive(mode)
 		receive.receive(setup.companion_port, false, "contest", function(tasks)
 			widgets.input(
 				"Choose contest directory",
-				eval_path(setup.received_contests_directory, tasks[1], setup.received_files_extension, setup.date_format),
+				eval_path(setup.received_contests_directory, tasks[1], setup.received_files_extension),
 				setup.floating_border,
 				not setup.received_contests_prompt_directory,
 				function(directory)
@@ -253,7 +252,7 @@ function M.receive(mode)
 						not cfg.received_contests_prompt_extension,
 						function(file_extension)
 							for _, task in ipairs(tasks) do
-								local filepath = directory .. "/" .. eval_path(cfg.received_contests_problems_path, task, file_extension, cfg.date_format)
+								local filepath = directory .. "/" .. eval_path(cfg.received_contests_problems_path, task, file_extension)
 								receive.store_problem_config(filepath, true, task, cfg)
 								if cfg.open_received_contests then
 									vim.cmd("edit " .. filepath)

--- a/lua/competitest/config.lua
+++ b/lua/competitest/config.lua
@@ -134,6 +134,7 @@ local default_config = {
 	receive_print_message = true,
 	template_file = false,
 	evaluate_template_modifiers = false,
+	date_format = "%c",
 	received_files_extension = "cpp",
 	received_problems_path = "$(CWD)/$(PROBLEM).$(FEXT)", -- where to store received problems, string or function
 	received_problems_prompt_path = true,
@@ -143,7 +144,6 @@ local default_config = {
 	received_contests_prompt_extension = true,
 	open_received_problems = true,
 	open_received_contests = true,
-	date_format = "%c",
 }
 
 ---Return an updated configuration table with given options

--- a/lua/competitest/config.lua
+++ b/lua/competitest/config.lua
@@ -143,6 +143,7 @@ local default_config = {
 	received_contests_prompt_extension = true,
 	open_received_problems = true,
 	open_received_contests = true,
+	date_format = "%c",
 }
 
 ---Return an updated configuration table with given options

--- a/lua/competitest/config.lua
+++ b/lua/competitest/config.lua
@@ -133,6 +133,7 @@ local default_config = {
 	companion_port = 27121, -- competitive companion port
 	receive_print_message = true,
 	template_file = false,
+	evaluate_template_modifiers = false,
 	received_files_extension = "cpp",
 	received_problems_path = "$(CWD)/$(PROBLEM).$(FEXT)", -- where to store received problems, string or function
 	received_problems_prompt_path = true,

--- a/lua/competitest/receive.lua
+++ b/lua/competitest/receive.lua
@@ -8,8 +8,9 @@ local M = {}
 ---@param task table: table with received task data
 ---@param file_extension string
 ---@param remove_illegal_characters boolean: whether to remove windows illegal characters from modifiers or not
+---@param date_format string: string used to format date
 ---@return string | nil: the converted string, or nil on failure
-function M.eval_receive_modifiers(str, task, file_extension, remove_illegal_characters)
+function M.eval_receive_modifiers(str, task, file_extension, remove_illegal_characters, date_format)
 	local judge, contest
 	local hyphen = string.find(task.group, " - ", 1, true)
 	if not hyphen then
@@ -34,6 +35,7 @@ function M.eval_receive_modifiers(str, task, file_extension, remove_illegal_char
 		["TIMELIM"] = tostring(task.timeLimit), -- time limit, timeLimit field
 		["JAVA_MAIN_CLASS"] = task.languages.java.mainClass, -- it's almost always 'Main'
 		["JAVA_TASK_CLASS"] = task.languages.java.taskClass, -- classname-friendly version of problem name
+		["DATE"] = tostring(os.date(date_format)),
 	}
 
 	if remove_illegal_characters and vim.fn.has("win32") == 1 then
@@ -156,6 +158,7 @@ end
 ---@param single_file_format string: string with CompetiTest file-format modifiers to match single testcases file name
 ---@param input_file_format string: string with CompetiTest file-format modifiers to match input files name
 ---@param output_file_format string: string with CompetiTest file-format modifiers to match output files name
+---@param date_format string: string used to format date
 function M.store_problem(
 	filepath,
 	template_file,
@@ -165,14 +168,15 @@ function M.store_problem(
 	use_single_file,
 	single_file_format,
 	input_file_format,
-	output_file_format
+	output_file_format,
+	date_format
 )
 	if template_file and utils.does_file_exist(template_file) then
 		utils.create_directory(vim.fn.fnamemodify(filepath, ":h"))
 		if evaluate_template then
 			local str = utils.load_file_as_string(template_file)
 			local extension = vim.fn.fnamemodify(template_file, ":e")
-			local evaluated_str = M.eval_receive_modifiers(str, task, extension, false)
+			local evaluated_str = M.eval_receive_modifiers(str, task, extension, false, date_format)
 			utils.write_string_on_file(filepath, evaluated_str)
 		else
 			luv.fs_copyfile(template_file, filepath)
@@ -234,7 +238,8 @@ function M.store_problem_config(filepath, confirm_overwriting, task, cfg)
 		cfg.testcases_use_single_file,
 		cfg.testcases_single_file_format,
 		cfg.testcases_input_file_format,
-		cfg.testcases_output_file_format
+		cfg.testcases_output_file_format,
+		cfg.date_format
 	)
 end
 


### PR DESCRIPTION
I've added this new feature that I personally find really neat to keep track of my solutions, and I think it could benefit others too. 

The idea behind this feature is to provide users with the ability to add a header comment at the start of each file automatically. This feature is useful for adding metadata about the problem such as the problem name, group, URL, memory limit, time limit and the starting time. 

If you decide to add a comment, you can use specific modifiers to insert dynamic information. For example, you can set the `head_comment` variable to "`//This file was generated at $(TIME)`", and it will automatically insert the current time in your preferred format, which can be specified with the `time_format` option, which allows you to specify how you'd like to display the time in your header comment. 

This feature is not mandatory; if you don't want a comment in your files, just set the `head_comment` variable to `false`.

The way I like to use it is something like this:
```lua
head_comment = "//Problem: $(NAME)\n//Contest: $(GROUP)\n//URL: $(URL)\n//Memory Limit: $(MEMLIM) MB\n//Time Limit: $(TIMELIM) ms\n//Start: $(TIME)",
time_format = "%d-%m-%Y %H:%M:%S"
```
which produces something like this on the top of every file:
```cpp
//Problem: A. Forbidden Integer
//Contest: Codeforces - Educational Codeforces Round 151 (Rated for Div. 2)
//URL: https://codeforces.com/contest/1845/problem/A
//Memory Limit: 256 MB
//Time Limit: 2000 ms
//Start: 06-07-2023 13:00:17
...
```