### PR TITLE
fix: update to load local configuration in receive function for problem and contest modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - Testcases can be stored in a single file or in multiple text files, see [usage notes](#usage-notes)
 - Easily [add](#add-or-edit-a-testcase), [edit](#add-or-edit-a-testcase) and [delete](#remove-a-testcase) testcases
 - [Run](#run-testcases) your program across all the testcases, showing results and execution data in a nice interactive UI
+- [Stress test](#stress-testing) your program with random test cases, comparing outputs with a correct solution
 - [Download](#receive-testcases-problems-and-contests) testcases, problems and contests automatically from competitive programming platforms
 - [Templates](#templates-for-received-problems-and-contests) for received problems and contests
 - View diff between actual and expected output
@@ -195,6 +196,18 @@ int main() {
 }
 ```
 
+## Stress Testing
+Launch `:CompetiTest stress` to start stress testing your program. The stress test window will appear showing:
+- Current status (Running/Stopped)
+- Runtime and number of tests passed
+- Current test seed and failed seeds
+- Generator, correct program and solution outputs when a test fails
+
+You can control the stress test with:
+- `K` to pause/continue testing
+- `q` to stop and exit
+
+
 ## Configuration
 ### Full configuration
 Here you can find CompetiTest default configuration
@@ -256,13 +269,27 @@ require('competitest').setup {
 			close_mappings = { "q", "Q" },
 		},
 	},
+	stress_ui = {
+		width = 0.5,
+		height = 0.6,
+		mappings = {
+			pause = "K",
+			close = "q",
+		},
+	},
 	popup_ui = {
 		total_width = 0.8,
 		total_height = 0.8,
 		layout = {
-			{ 4, "tc" },
-			{ 5, { { 1, "so" }, { 1, "si" } } },
-			{ 5, { { 1, "eo" }, { 1, "se" } } },
+			{ 3, "tc" },
+			{ 4, {
+				{ 1, "so" },
+				{ 1, "si" },
+			} },
+			{ 4, {
+				{ 1, "eo" },
+				{ 1, "se" },
+			} },
 		},
 	},
 	split_ui = {
@@ -298,6 +325,21 @@ require('competitest').setup {
 		rust = { exec = "./$(FNOEXT)" },
 		python = { exec = "python", args = { "$(FNAME)" } },
 		java = { exec = "java", args = { "$(FNOEXT)" } },
+	},
+	stress = {
+		generator = {
+			exec = "./$(FNOEXT)_gen",
+			args = { "$(SEED)" },
+		},
+		correct = {
+			exec = "./$(FNOEXT)_correct",
+		},
+		solution = {
+			exec = "./$(FNOEXT)",
+		},
+		time_limit = 5000,
+		seed_range = { 1, 1000000000 },
+		auto_continue = true,
 	},
 	multiple_testing = -1,
 	maximum_time = 5000,
@@ -379,6 +421,17 @@ require('competitest').setup {
 	- `vertical_layout`: a table describing vertical split UI layout. For further details see [here](#customize-ui-layout)
 	- `total_height`: a value from 0 to 1, representing the ratio between total **horizontal** split height and relative window height
 	- `horizontal_layout`: a table describing horizontal split UI layout. For further details see [here](#customize-ui-layout)
+- `stress`: settings related to stress testing
+	- `generator`: settings related to stress test generator
+		- `exec`: command used to generate testcases
+		- `args`: arguments passed to the generator command
+	- `correct`: settings related to stress test correct program
+		- `exec`: command used to run correct program
+	- `solution`: settings related to stress test solution program
+		- `exec`: command used to run solution program
+	- `time_limit`: time limit for each test case, in milliseconds
+	- `seed_range`: range of random seeds
+	- `auto_continue`: whether to continue testing automatically
 - `save_current_file`: if true save current file before running testcases
 - `save_all_files`: if true save all the opened files before running testcases
 - `compile_directory`: execution directory of compiler, relatively to current file's path

--- a/lua/competitest/commands.lua
+++ b/lua/competitest/commands.lua
@@ -301,7 +301,7 @@ function M.receive(mode)
 			receive.store_testcases(bufnr, tasks[1].tests, bufcfg.testcases_use_single_file, bufcfg.replace_received_testcases)
 		end)
 	elseif mode == "problem" then
-		local setup = config.current_setup
+		local setup = config.load_local_config_and_extend(vim.fn.getcwd())
 		local notify_string = setup.receive_print_message and "problem" or nil
 		receive.receive(setup.companion_port, true, notify_string, function(tasks)
 			widgets.input(
@@ -319,7 +319,7 @@ function M.receive(mode)
 			)
 		end)
 	elseif mode == "contest" then
-		local setup = config.current_setup
+		local setup = config.load_local_config_and_extend(vim.fn.getcwd())
 		local notify_string = setup.receive_print_message and "contest" or nil
 		receive.receive(setup.companion_port, false, notify_string, function(tasks)
 			widgets.input(

--- a/lua/competitest/commands.lua
+++ b/lua/competitest/commands.lua
@@ -76,6 +76,11 @@ function M.command(args)
 				M.receive(args[2])
 			end
 		end,
+		stress = function()
+			if check_subargs(0, 0) then
+				M.run_stress_test()
+			end
+		end,
 	}
 
 	local sub = subcommands[args[1]]
@@ -350,6 +355,26 @@ function M.receive(mode)
 	else
 		utils.notify("receive: unrecognized mode '" .. tostring(mode) .. "'.")
 	end
+end
+
+---Run stress test
+function M.run_stress_test()
+	local bufnr = api.nvim_get_current_buf()
+	config.load_buffer_config(bufnr)
+
+	if not M.runners[bufnr] then
+		M.runners[bufnr] = require("competitest.runner"):new(api.nvim_get_current_buf())
+		if not M.runners[bufnr] then
+			return
+		end
+		api.nvim_command("autocmd BufUnload <buffer=" .. bufnr .. "> lua require('competitest.commands').remove_runner(vim.fn.expand('<abuf>'))")
+	end
+
+	local r = M.runners[bufnr]
+	r:kill_all_processes()
+	r:run_stress_test()
+	r:set_restore_winid(api.nvim_get_current_win())
+	r:show_ui()
 end
 
 return M

--- a/lua/competitest/config.lua
+++ b/lua/competitest/config.lua
@@ -57,6 +57,14 @@ local default_config = {
 			close_mappings = { "q", "Q" },
 		},
 	},
+	stress_ui = { -- user interface used by CompetiTest stress
+		width = 0.5, -- from 0 to 1
+		height = 0.6, -- from 0 to 1
+		mappings = {
+			pause = "K", -- pause/continue stress test
+			close = "q", -- stop and exit stress test
+		},
+	},
 	popup_ui = {
 		total_width = 0.8, -- from 0 to 1, total width of popup ui
 		total_height = 0.8, -- from 0 to 1, total height of popup ui
@@ -117,6 +125,21 @@ local default_config = {
 		rust = { exec = "./$(FNOEXT)" },
 		python = { exec = "python", args = { "$(FNAME)" } },
 		java = { exec = "java", args = { "$(FNOEXT)" } },
+	},
+	stress = {
+		generator = {
+			exec = "./$(FNOEXT)_gen",
+			args = { "$(SEED)" },
+		},
+		correct = {
+			exec = "./$(FNOEXT)_correct",
+		},
+		solution = {
+			exec = "./$(FNOEXT)",
+		},
+		time_limit = 5000, -- Time limit for each test case (ms)
+		seed_range = { 1, 1000000000 }, -- Range of random seeds
+		auto_continue = true, -- Whether to continue testing automatically
 	},
 	multiple_testing = -1, -- how many testcases to run at the same time. Set it to 0 to run all them together, -1 to use amount of available parallelism, or any positive number to run how many testcases you want
 	maximum_time = 5000, -- maximum time (in milliseconds) given to a process. If it's excedeed process will be killed

--- a/lua/competitest/init.lua
+++ b/lua/competitest/init.lua
@@ -18,7 +18,7 @@ function M.setup(opts)
 			let wlen = len(words)
 
 			if wlen == 1 || wlen == 2 && !ending_space
-				return "add_testcase\nedit_testcase\ndelete_testcase\nconvert\nrun\nrun_no_compile\nshow_ui\nreceive"
+				return "add_testcase\nedit_testcase\ndelete_testcase\nconvert\nrun\nrun_no_compile\nshow_ui\nreceive\nstress"
 			elseif wlen == 2 || wlen == 3 && !ending_space
 				if wlen == 2
 					let lastword = words[-1]

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 local nui_event = require("nui.utils.autocmd").event
 local utils = require("competitest.utils")
+local Popup = require("nui.popup")
 
 local RunnerUI = {}
 RunnerUI.__index = RunnerUI
@@ -62,9 +63,30 @@ function RunnerUI:resize_ui()
 	end
 end
 
----Show Runner UI if not already shown
----It initializes UI if called for the first time or resized
+---Show Runner UI
 function RunnerUI:show_ui()
+	-- If in stress test mode, only show stress test window
+	if self.runner.stress_data and not self.runner.tcdata then
+		-- Clean up existing normal test windows
+		if self.ui_initialized then
+			self:delete()
+		end
+		self:show_stress_ui()
+		self:update_stress_view(self.runner.stress_data)
+		return
+	end
+
+	-- If in normal test mode but no test data, return directly
+	if not self.runner.tcdata or next(self.runner.tcdata) == nil then
+		return
+	end
+
+	-- Clean up existing stress test windows
+	if self.windows.stress then
+		self.windows.stress:unmount()
+		self.windows.stress = nil
+	end
+
 	if not self.ui_initialized or (self.interface.init_ui_only and not self.ui_visible) then -- initialize ui
 		self.interface.init_ui(self.windows, self.runner.config, self.restore_winid)
 
@@ -353,7 +375,18 @@ end
 ---Update Runner UI
 function RunnerUI:update_ui()
 	vim.schedule(function()
-		if not self.ui_visible or next(self.runner.tcdata) == nil then
+		if not self.ui_visible then
+			return
+		end
+
+		-- If in stress test mode and has stress test data
+		if self.runner.stress_data and not self.runner.tcdata then
+			self:update_stress_view(self.runner.stress_data)
+			return
+		end
+
+		-- If in normal test mode
+		if not self.runner.tcdata or next(self.runner.tcdata) == nil then
 			return
 		end
 
@@ -419,6 +452,250 @@ function RunnerUI:update_ui()
 		if self.make_viewer_visible then
 			self.make_viewer_visible = nil
 			self:show_viewer_popup()
+		end
+	end)
+end
+
+---显示对拍界面
+---@param self RunnerUI
+function RunnerUI:show_stress_ui()
+	if not self.windows.stress then
+		local vim_width, vim_height = utils.get_ui_size()
+		local width = math.max(40, math.floor(vim_width * self.runner.config.stress_ui.width))
+		local height = math.max(20, math.floor(vim_height * self.runner.config.stress_ui.height))
+
+		local popup_options = {
+			enter = true,
+			focusable = true,
+			border = {
+				style = self.runner.config.floating_border,
+				highlight = self.runner.config.floating_border_highlight,
+				text = {
+					top = " Stress Test ",
+					top_align = "center",
+				},
+			},
+			relative = "editor",
+			position = {
+				row = math.floor((vim_height - height) / 2),
+				col = math.floor((vim_width - width) / 2),
+			},
+			size = {
+				width = width,
+				height = height,
+			},
+			buf_options = {
+				modifiable = true,
+				buftype = "nofile",
+				swapfile = false,
+			},
+			win_options = {
+				number = false,
+				relativenumber = false,
+				cursorline = true,
+				wrap = false,
+			},
+		}
+
+		self.windows.stress = Popup(popup_options)
+		self.windows.stress:mount()
+
+		-- 设置按键映射
+		for action, maps in pairs(self.runner.config.stress_ui.mappings) do
+			if type(maps) == "string" then -- turn string into table
+				self.runner.config.stress_ui.mappings[action] = { maps }
+			end
+		end
+
+		-- 暂停/继续对拍
+		for _, map in ipairs(self.runner.config.stress_ui.mappings.pause) do
+			self.windows.stress:map("n", map, function()
+				if self.runner.stress_data.running then
+					self.runner.stress_data.running = false
+				else
+					self.runner:start_stress_test()
+				end
+			end, { noremap = true })
+		end
+
+		-- 停止并退出对拍
+		local function close_stress_window()
+			if self.runner and self.runner.stress_data then
+				self.runner.stress_data.running = false
+			end
+			self:hide_stress_ui()
+		end
+
+		for _, map in ipairs(self.runner.config.stress_ui.mappings.close) do
+			self.windows.stress:map("n", map, close_stress_window, { noremap = true })
+			self.windows.stress:on(nui_event.QuitPre, close_stress_window)
+		end
+	end
+
+	self.windows.stress:show()
+end
+
+---隐藏对拍界面
+---@param self RunnerUI
+function RunnerUI:hide_stress_ui()
+	if self.windows.stress then
+		self.windows.stress:hide()
+		if self.restore_winid and api.nvim_win_is_valid(self.restore_winid) then
+			api.nvim_set_current_win(self.restore_winid)
+		end
+	end
+end
+
+---删除对拍界面
+---@param self RunnerUI
+function RunnerUI:delete_stress_ui()
+	if self.windows.stress then
+		self.windows.stress:unmount()
+		self.windows.stress = nil
+		if self.restore_winid and api.nvim_win_is_valid(self.restore_winid) then
+			api.nvim_set_current_win(self.restore_winid)
+		end
+	end
+end
+
+---更新对拍窗口
+---@param self RunnerUI
+---@param stress_data StressData
+function RunnerUI:update_stress_view(stress_data)
+	vim.schedule(function()
+		if not self.windows.stress then
+			self:show_stress_ui()
+			return
+		end
+
+		-- 更新内容
+		local lines = {}
+		local runtime = stress_data and stress_data.start_time and (os.time() - stress_data.start_time) or 0
+		local status = stress_data and stress_data.running and "Running" or "Stopped"
+
+		table.insert(lines, "Status")
+		table.insert(lines, "       " .. status)
+		table.insert(lines, "")
+		table.insert(lines, "Runtime")
+		table.insert(lines, string.format("       %ds", runtime))
+		table.insert(lines, "")
+		table.insert(lines, "Tests Passed")
+		table.insert(lines, string.format("       %d", stress_data and stress_data.passed or 0))
+		table.insert(lines, "")
+
+		if stress_data and stress_data.error_messages and #stress_data.error_messages > 0 then
+			table.insert(lines, "Errors")
+			for _, msg in ipairs(stress_data.error_messages) do
+				table.insert(lines, "       " .. msg)
+			end
+			table.insert(lines, "")
+		end
+
+		if stress_data and stress_data.current_seed then
+			table.insert(lines, "Current Seed")
+			table.insert(lines, string.format("       %d", stress_data.current_seed))
+			table.insert(lines, "")
+		end
+
+		if stress_data and stress_data.outputs then
+			if stress_data.outputs.generator then
+				if stress_data.outputs.generator.exit_code ~= 0 then
+					table.insert(lines, "Generator")
+					table.insert(lines, string.format("       Exit Code: %d", stress_data.outputs.generator.exit_code))
+					table.insert(lines, string.format("       Path: %s", self.runner.stress_data and self.runner.stress_data.gen_exec or ""))
+					table.insert(lines, string.format("       Args: %s", self.runner.stress_data and table.concat(self.runner.stress_data.gen_args, " ") or ""))
+					table.insert(lines, string.format("       Working Directory: %s", self.runner.running_directory or ""))
+					if #stress_data.outputs.generator.stderr > 0 then
+						table.insert(lines, "       Stderr:")
+						for _, line in ipairs(stress_data.outputs.generator.stderr) do
+							if line and line ~= "" then
+								table.insert(lines, "              " .. line)
+							end
+						end
+					end
+					table.insert(lines, "")
+				end
+			end
+
+			if stress_data.outputs.correct then
+				if stress_data.outputs.correct.exit_code ~= 0 then
+					table.insert(lines, "Correct Program")
+					table.insert(lines, string.format("       Exit Code: %d", stress_data.outputs.correct.exit_code))
+					table.insert(lines, string.format("       Path: %s", self.runner.stress_data and self.runner.stress_data.correct_exec or ""))
+					table.insert(lines, string.format("       Args: %s", self.runner.stress_data and table.concat(self.runner.stress_data.correct_args, " ") or ""))
+					table.insert(lines, string.format("       Working Directory: %s", self.runner.running_directory or ""))
+					if #stress_data.outputs.correct.stderr > 0 then
+						table.insert(lines, "       Stderr:")
+						for _, line in ipairs(stress_data.outputs.correct.stderr) do
+							if line and line ~= "" then
+								table.insert(lines, "              " .. line)
+							end
+						end
+					end
+					table.insert(lines, "")
+				end
+			end
+
+			if stress_data.outputs.solution then
+				if stress_data.outputs.solution.exit_code ~= 0 then
+					table.insert(lines, "Solution")
+					table.insert(lines, string.format("       Exit Code: %d", stress_data.outputs.solution.exit_code))
+					table.insert(lines, string.format("       Path: %s", self.runner.stress_data and self.runner.stress_data.solution_exec or ""))
+					table.insert(lines, string.format("       Working Directory: %s", self.runner.running_directory or ""))
+					if #stress_data.outputs.solution.stderr > 0 then
+						table.insert(lines, "       Stderr:")
+						for _, line in ipairs(stress_data.outputs.solution.stderr) do
+							if line and line ~= "" then
+								table.insert(lines, "              " .. line)
+							end
+						end
+					end
+					table.insert(lines, "")
+				end
+			end
+		end
+
+		if stress_data and stress_data.failed_seeds and #stress_data.failed_seeds > 0 then
+			table.insert(lines, "Failed Seeds")
+			for _, seed in ipairs(stress_data.failed_seeds) do
+				table.insert(lines, string.format("       %d", seed))
+			end
+			table.insert(lines, "")
+
+			local last_seed = stress_data.failed_seeds[#stress_data.failed_seeds]
+			if stress_data.outputs and stress_data.outputs.generator and stress_data.outputs.correct and stress_data.outputs.solution then
+				table.insert(lines, string.format("Last Failed Test (Seed %d)", last_seed))
+				table.insert(lines, "")
+				table.insert(lines, "Generator Output")
+				for _, line in ipairs(stress_data.outputs.generator.stdout) do
+					if line and line ~= "" then
+						table.insert(lines, "       " .. line)
+					end
+				end
+				table.insert(lines, "")
+				table.insert(lines, "Correct Program Output")
+				for _, line in ipairs(stress_data.outputs.correct.stdout) do
+					if line and line ~= "" then
+						table.insert(lines, "       " .. line)
+					end
+				end
+				table.insert(lines, "")
+				table.insert(lines, "Solution Output")
+				for _, line in ipairs(stress_data.outputs.solution.stdout) do
+					if line and line ~= "" then
+						table.insert(lines, "       " .. line)
+					end
+				end
+				table.insert(lines, "")
+			end
+		end
+
+		table.insert(lines, "Key Help")
+		table.insert(lines, string.format("       %s        Pause/Continue", self.runner.config.stress_ui.mappings.pause[1]))
+		table.insert(lines, string.format("       %s        Stop and Exit", self.runner.config.stress_ui.mappings.close[1]))
+
+		if self.windows.stress and self.windows.stress.bufnr then
+			api.nvim_buf_set_lines(self.windows.stress.bufnr, 0, -1, false, lines)
 		end
 	end)
 end

--- a/lua/competitest/utils.lua
+++ b/lua/competitest/utils.lua
@@ -1,11 +1,12 @@
 local luv = vim.loop
 local M = {}
 
----Show a CompetiTest notification with vim.notify()
----@param msg string: message to display
----@param log_level string | nil: a log level among the ones available in vim.log.levels. When nil it defaults to ERROR
-function M.notify(msg, log_level)
-	vim.notify("CompetiTest.nvim: " .. msg, vim.log.levels[log_level or "ERROR"], { title = "CompetiTest" })
+---Show a notification message
+---@param msg string: message to show
+function M.notify(msg)
+	vim.schedule(function()
+		vim.api.nvim_echo({ { "CompetiTest: " .. msg, "Normal" } }, true, {})
+	end)
 end
 
 ---Convert a string with CompetiTest modifiers into a formatted string
@@ -86,6 +87,9 @@ M.file_format_modifiers = {
 
 	-- $(TCNUM): testcase number; it will be set later
 	["TCNUM"] = nil,
+
+	-- $(SEED): stress test seed; it will be set later
+	["SEED"] = nil,
 }
 
 ---Convert a string with CompetiTest file-format modifiers into a formatted string


### PR DESCRIPTION
When running the command `problem` and `contest`, read the config file of the current working directory, so that configuration items such as `received_problems_path` can be set in the config file of the current directory.