### PR TITLE
DIfferent runner UI if compilation goes wrong

### DIFF
--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -195,8 +195,8 @@ function TCRunner:execute_testcase(tcindex, exec, args, dir, callback)
 			tc.timer:stop()
 			tc.timer:close()
 		end
-
-		self:update_ui(true, exit_signal ~= 0 and tcindex == 1)
+        
+		self:update_ui(true, tc.status ~= "DONE" and tcindex == 1)
 		if callback then
 			callback()
 		end

--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -129,6 +129,10 @@ function TCRunner:run_testcases(tctbl, compile)
 		end
 	end
 
+    local function toggle_compilation_error_ui()
+        print("compialtion error")
+    end
+
 	if not self.compile then
 		run_first_testcases()
 	else
@@ -137,7 +141,7 @@ function TCRunner:run_testcases(tctbl, compile)
 			if self.tcdata[1].exit_code == 0 then
 				run_first_testcases()
             else
-                print("compilazione errata")
+                toggle_compilation_error_ui()
 			end
 		end
 

--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -129,10 +129,6 @@ function TCRunner:run_testcases(tctbl, compile)
 		end
 	end
 
-    local function toggle_compilation_error_ui()
-        print("compialtion error")
-    end
-
 	if not self.compile then
 		run_first_testcases()
 	else
@@ -140,8 +136,6 @@ function TCRunner:run_testcases(tctbl, compile)
 		local function compilation_callback()
 			if self.tcdata[1].exit_code == 0 then
 				run_first_testcases()
-            else
-                toggle_compilation_error_ui()
 			end
 		end
 
@@ -202,7 +196,7 @@ function TCRunner:execute_testcase(tcindex, exec, args, dir, callback)
 			tc.timer:close()
 		end
 
-		self:update_ui(true)
+		self:update_ui(true, exit_signal ~= 0 and tcindex == 1)
 		if callback then
 			callback()
 		end
@@ -338,12 +332,16 @@ end
 
 ---Update Runner UI content
 ---@param update_windows boolean | nil: whether to update all the windows or only details windows
-function TCRunner:update_ui(update_windows)
+---@param compilation_error boolean | nil: whether to pass to the compialtion error view
+function TCRunner:update_ui(update_windows, compilation_error)
 	if self.ui then
 		if update_windows then -- avoid direct assignment to satisfy unprocessed previous update_windows requests
 			self.ui.update_windows = true
 		end
 		self.ui.update_details = true
+        if compilation_error then
+            print("ciao")
+        end
 		self.ui:update_ui()
 	end
 end

--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -339,10 +339,7 @@ function TCRunner:update_ui(update_windows, compilation_error)
 			self.ui.update_windows = true
 		end
 		self.ui.update_details = true
-        if compilation_error then
-            print("ciao")
-        end
-		self.ui:update_ui()
+		self.ui:update_ui(compilation_error)
 	end
 end
 

--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -136,6 +136,8 @@ function TCRunner:run_testcases(tctbl, compile)
 		local function compilation_callback()
 			if self.tcdata[1].exit_code == 0 then
 				run_first_testcases()
+            else
+                print("compilazione errata")
 			end
 		end
 

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -308,8 +308,8 @@ function RunnerUI:show_viewer_popup(window_name)
 			},
 			relative = "editor",
 			size = {
-				width = math.floor(vim_width * self.runner.config.runner_ui.viewer.width),
-				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height),
+				width = math.floor(vim_width * self.runner.config.runner_ui.viewer.width + 1),
+				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height + 1),
 			},
 			position = "50%",
 			win_options = {

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -358,7 +358,7 @@ function RunnerUI:update_ui(compilation_error)
 			return
 		end
         
-        if compilation_error
+        if compilation_error then
 			self:show_viewer_popup("se")
         end
 

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -308,8 +308,8 @@ function RunnerUI:show_viewer_popup(window_name)
 			},
 			relative = "editor",
 			size = {
-				width = math.floor(self.runner.config.runner_ui.viewer.width),
-				height = math.floor(self.runner.config.runner_ui.viewer.height),
+				width = math.floor(vim_width * self.runner.config.runner_ui.viewer.width + 10),
+				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height + 10),
 			},
 			position = "50%",
 			win_options = {

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -351,11 +351,16 @@ local function adjust_string(len, str, fchar)
 end
 
 ---Update Runner UI
-function RunnerUI:update_ui()
+---@param compilation_error boolean | nil: whether to pass to the compialtion error view
+function RunnerUI:update_ui(compilation_error)
 	vim.schedule(function()
 		if not self.ui_visible or next(self.runner.tcdata) == nil then
 			return
 		end
+        
+        if compilation_error
+			self:show_viewer_popup("se")
+        end
 
 		-- update windows content if not already updated
 		if self.update_windows then

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -357,7 +357,7 @@ function RunnerUI:update_ui(compilation_error)
 		if not self.ui_visible or next(self.runner.tcdata) == nil then
 			return
 		end
-        
+
         if compilation_error then
 			self:show_viewer_popup("se")
             return

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -311,7 +311,7 @@ function RunnerUI:show_viewer_popup(window_name)
 				width = self.runner.config.runner_ui.viewer.width,
 				height = self.runner.config.runner_ui.viewer.height,
 			},
-			position = "50%",
+			position = "100%",
 			win_options = {
 				number = self.runner.config.runner_ui.viewer.show_nu,
 				relativenumber = self.runner.config.runner_ui.viewer.show_rnu,
@@ -359,6 +359,7 @@ function RunnerUI:update_ui(compilation_error)
 		end
         
         if compilation_error then
+            self:hide_ui()
 			self:show_viewer_popup("se")
         end
 

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -360,6 +360,7 @@ function RunnerUI:update_ui(compilation_error)
         
         if compilation_error then
 			self:show_viewer_popup("se")
+            return
         end
 
 		-- update windows content if not already updated

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -308,10 +308,10 @@ function RunnerUI:show_viewer_popup(window_name)
 			},
 			relative = "editor",
 			size = {
-				width = self.runner.config.runner_ui.viewer.width,
-				height = self.runner.config.runner_ui.viewer.height,
+				width = math.floor(vim_width * self.runner.config.popup_ui.total_width + 0.5),
+				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height + 0.5),
 			},
-			position = "100%",
+			position = "50%",
 			win_options = {
 				number = self.runner.config.runner_ui.viewer.show_nu,
 				relativenumber = self.runner.config.runner_ui.viewer.show_rnu,

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -309,7 +309,7 @@ function RunnerUI:show_viewer_popup(window_name)
 			relative = "editor",
 			size = {
 				width = math.floor(vim_width * self.runner.config.popup_ui.total_width + 0.5),
-				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height + 0.5),
+				height = math.floor(vim_height * self.runner.config.popup_ui.total_height + 0.5),
 			},
 			position = "50%",
 			win_options = {
@@ -359,7 +359,6 @@ function RunnerUI:update_ui(compilation_error)
 		end
         
         if compilation_error then
-            self:hide_ui()
 			self:show_viewer_popup("se")
         end
 

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -308,8 +308,8 @@ function RunnerUI:show_viewer_popup(window_name)
 			},
 			relative = "editor",
 			size = {
-				width = math.floor(vim_width * self.runner.config.runner_ui.viewer.width + 1),
-				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height + 1),
+				width = math.floor(vim_width),
+				height = math.floor(vim_height),
 			},
 			position = "50%",
 			win_options = {

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -308,8 +308,8 @@ function RunnerUI:show_viewer_popup(window_name)
 			},
 			relative = "editor",
 			size = {
-				width = math.floor(vim_width),
-				height = math.floor(vim_height),
+				width = math.floor(self.runner.config.runner_ui.viewer.width),
+				height = math.floor(self.runner.config.runner_ui.viewer.height),
 			},
 			position = "50%",
 			win_options = {

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -308,8 +308,8 @@ function RunnerUI:show_viewer_popup(window_name)
 			},
 			relative = "editor",
 			size = {
-				width = math.floor(vim_width * self.runner.config.runner_ui.viewer.width + 10),
-				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height + 10),
+				width = self.runner.config.runner_ui.viewer.width,
+				height = self.runner.config.runner_ui.viewer.height,
 			},
 			position = "50%",
 			win_options = {

--- a/lua/competitest/runner_ui/init.lua
+++ b/lua/competitest/runner_ui/init.lua
@@ -308,8 +308,8 @@ function RunnerUI:show_viewer_popup(window_name)
 			},
 			relative = "editor",
 			size = {
-				width = math.floor(vim_width * self.runner.config.runner_ui.viewer.width + 0.5),
-				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height + 0.5),
+				width = math.floor(vim_width * self.runner.config.runner_ui.viewer.width),
+				height = math.floor(vim_height * self.runner.config.runner_ui.viewer.height),
 			},
 			position = "50%",
 			win_options = {

--- a/lua/competitest/runner_ui/popup.lua
+++ b/lua/competitest/runner_ui/popup.lua
@@ -95,7 +95,7 @@ function M.init_ui(windows, config)
 	windows.so = nui_popup(popup_settings)
 
 	-- expected output popup
-	popup_settings.border.text.top = " Expected Output FRAA"
+	popup_settings.border.text.top = " Expected Output"
 	popup_settings.size = sizes["eo"]
 	popup_settings.position = positions["eo"]
 	windows.eo = nui_popup(popup_settings)

--- a/lua/competitest/runner_ui/popup.lua
+++ b/lua/competitest/runner_ui/popup.lua
@@ -95,7 +95,7 @@ function M.init_ui(windows, config)
 	windows.so = nui_popup(popup_settings)
 
 	-- expected output popup
-	popup_settings.border.text.top = " Expected Output "
+	popup_settings.border.text.top = " Expected Output FRAA"
 	popup_settings.size = sizes["eo"]
 	popup_settings.position = positions["eo"]
 	windows.eo = nui_popup(popup_settings)


### PR DESCRIPTION
This is my first ever pull request as well as my first time programming in lua so feedback is welcomed. 

I've tried to make it so that, when compilation fails, a popup window is opened on top of the usual runner UI as to better display stderr. In my opinion the option to type 'e' or 'E' to make stderr bigger was not making it big enough, furthermore there is no point in viewing testcases if compilation has failed.