### PR TITLE
feat: add run_empty_testcase option

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ require('competitest').setup {
 
 	save_current_file = true,
 	save_all_files = false,
+	run_empty_testcase = false,
 	compile_directory = ".",
 	compile_command = {
 		c = { exec = "gcc", args = { "-Wall", "$(FNAME)", "-o", "$(FNOEXT)" } },
@@ -385,6 +386,7 @@ require('competitest').setup {
 	- `horizontal_layout`: a table describing horizontal split UI layout. For further details see [here](#customize-ui-layout)
 - `save_current_file`: if true save current file before running testcases
 - `save_all_files`: if true save all the opened files before running testcases
+- `run_empty_testcase`  if true and no testcases are provided, run an empty one
 - `compile_directory`: execution directory of compiler, relatively to current file's path
 - `compile_command`: configure the command used to compile code for every different language, see [here](#customize-compile-and-run-commands)
 - `running_directory`: execution directory of your solutions, relatively to current file's path

--- a/lua/competitest/config.lua
+++ b/lua/competitest/config.lua
@@ -64,6 +64,7 @@
 ---@field split_ui competitest.Config.split_ui
 ---@field save_current_file boolean save current file before running testcases
 ---@field save_all_files boolean save all the opened files before running testcases
+---@field run_empty_testcase boolean if no testcases are provided, run an empty one
 ---@field compile_directory string working directory of compiler, relative to current file path
 ---@field compile_command { [string]: competitest.SystemCommand } command used to compile code, for each file type
 ---@field running_directory string working directory of your solutions, relative to current file path
@@ -200,6 +201,7 @@ local default_config = {
 
 	save_current_file = true,
 	save_all_files = false,
+	run_empty_testcase = false,
 	compile_directory = ".",
 	compile_command = {
 		c = { exec = "gcc", args = { "-Wall", "$(FNAME)", "-o", "$(FNOEXT)" } },

--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -156,6 +156,9 @@ function TCRunner:run_testcases(tctbl, compile)
 		if self.compile then -- if compilation is needed we add it as a testcase
 			table.insert(self.tcdata, { stdin = {}, expout = nil, tcnum = "Compile" })
 		end
+		if self.config.run_empty_testcase and #tctbl == 0 then
+			tctbl[0] = { input = "" }
+		end
 		for tcnum, tc in pairs(tctbl) do
 			table.insert(self.tcdata, {
 				stdin = vim.split(tc.input, "\n", { plain = true }),

--- a/lua/competitest/runner.lua
+++ b/lua/competitest/runner.lua
@@ -156,7 +156,7 @@ function TCRunner:run_testcases(tctbl, compile)
 		if self.compile then -- if compilation is needed we add it as a testcase
 			table.insert(self.tcdata, { stdin = {}, expout = nil, tcnum = "Compile" })
 		end
-		if self.config.run_empty_testcase and #tctbl == 0 then
+		if self.config.run_empty_testcase and tctbl[0] == nil then
 			tctbl[0] = { input = "" }
 		end
 		for tcnum, tc in pairs(tctbl) do


### PR DESCRIPTION
Thanks for the plugin! Sometimes when I use it not only for competitive programming but just to execute my current file, but have to add a "dummy" empty test case so that `:CompetiTest run` actually executes the program. I would like that if no testcases are provided, the program is runned on an empty one. This PR adds a `run_empty_testcase` option which lets the user choose whether this behavior is followed or not (not sure for the naming of it though, perhaps one should add `by_default` or something to clarify its purpose).